### PR TITLE
build: report to buildtracker on commit via ghactions

### DIFF
--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -11,6 +11,9 @@ jobs:
   basics:
 
     runs-on: ubuntu-latest
+    strategy:
+      # e.g. if lint fails, continue to the unit tests anyway
+      fail-fast: false
 
     steps:
     - name: git clone

--- a/.github/workflows/basics.yml
+++ b/.github/workflows/basics.yml
@@ -21,7 +21,7 @@ jobs:
       with:
         node-version: 10.x
 
-   # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
+    # Cache yarn deps. thx https://github.com/actions/cache/blob/master/examples.md#node---yarn
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/master-commit.yml
+++ b/.github/workflows/master-commit.yml
@@ -26,7 +26,7 @@ jobs:
     - run: yarn build-all
 
     - name: Store in buildtracker
-    - uses: paularmstrong/build-tracker-action@master
+      uses: paularmstrong/build-tracker-action@master
       with:
         # https://buildtracker.dev/docs/guides/github-actions#configuration
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master-commit.yml
+++ b/.github/workflows/master-commit.yml
@@ -1,0 +1,33 @@
+# Workflow that only runs when a commit lands on master.
+
+name: 🛬
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  # This job could be renamed more generically if we add other steps in here
+  buildtracker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: git clone
+      uses: actions/checkout@v2
+
+    - name: Use Node.js 10.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+
+    - run: yarn --frozen-lockfile
+    - run: yarn build-all
+
+    - name: Store in buildtracker
+    - uses: paularmstrong/build-tracker-action@master
+      with:
+        # https://buildtracker.dev/docs/guides/github-actions#configuration
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BT_API_AUTH_TOKEN: ${{ secrets.BT_API_AUTH_TOKEN }}

--- a/build-tracker.config.js
+++ b/build-tracker.config.js
@@ -1,0 +1,14 @@
+// https://buildtracker.dev/docs/installation/#upload-your-builds
+
+module.exports = {
+  applicationUrl: 'https://lh-build-tracker.herokuapp.com',
+  artifacts: [
+    "dist/lightrider/lighthouse-lr-bundle.js",
+    "dist/extension/scripts/lighthouse-ext-bundle.js",
+    "dist/lighthouse-dt-bundle.js",
+    "dist/viewer/src/viewer.js",
+    "dist/lightrider/report-generator-bundle.js",
+    "dist/dt-report-resources/report.js",
+    "dist/dt-report-resources/report-generator.js",
+  ]
+};

--- a/build-tracker.config.js
+++ b/build-tracker.config.js
@@ -1,6 +1,6 @@
 // https://buildtracker.dev/docs/installation/#upload-your-builds
 
-"use strict";
+'use strict';
 
 module.exports = {
   applicationUrl: 'https://lh-build-tracker.herokuapp.com',

--- a/build-tracker.config.js
+++ b/build-tracker.config.js
@@ -1,14 +1,16 @@
 // https://buildtracker.dev/docs/installation/#upload-your-builds
 
+"use strict";
+
 module.exports = {
   applicationUrl: 'https://lh-build-tracker.herokuapp.com',
   artifacts: [
-    "dist/lightrider/lighthouse-lr-bundle.js",
-    "dist/extension/scripts/lighthouse-ext-bundle.js",
-    "dist/lighthouse-dt-bundle.js",
-    "dist/viewer/src/viewer.js",
-    "dist/lightrider/report-generator-bundle.js",
-    "dist/dt-report-resources/report.js",
-    "dist/dt-report-resources/report-generator.js",
-  ]
+    'dist/lightrider/lighthouse-lr-bundle.js',
+    'dist/extension/scripts/lighthouse-ext-bundle.js',
+    'dist/lighthouse-dt-bundle.js',
+    'dist/viewer/src/viewer.js',
+    'dist/lightrider/report-generator-bundle.js',
+    'dist/dt-report-resources/report.js',
+    'dist/dt-report-resources/report-generator.js',
+  ],
 };


### PR DESCRIPTION
testing this out in my fork first...

-----------

I've set up https://buildtracker.dev/ and backfilled it with the last 18months of commits:
https://lh-build-tracker.herokuapp.com/builds/limit/1000

![image](https://user-images.githubusercontent.com/39191/77115863-548dd100-69ec-11ea-9ac9-a6c3a37bc3e0.png)

The UX takes some clicking around to get used to but its pretty powerful.



This PR adds a github action workflow that will report to buildtracker for every master commit. 
